### PR TITLE
Reward shaping + fix crash pomme rouge fatale

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -49,6 +49,16 @@ REWARD_RED = -20
 REWARD_NOTHING = -1
 REWARD_GAMEOVER = -100
 
+# --- Reward shaping (rapprochement des pommes) -----------------------------
+# L'etat ne code la pomme verte que par un bit "visible / pas visible" (sans
+# distance) : avancer vers une pomme visible ne change pas l'etat et rapporte
+# le meme -1 que s'en eloigner. Sans gradient, le serpent erre et tourne en
+# rond au lieu de manger. On ajoute donc un bonus proportionnel a la reduction
+# de distance a la pomme verte visible la plus proche (rapprochement +, recul
+# -, distance inchangee 0). Calcule uniquement a partir des rayons de vision,
+# donc conforme a la contrainte "vision seule".
+REWARD_APPROACH = 1.0
+
 # --- Anti-blocage ----------------------------------------------------------
 # En exploitation pure (epsilon=0, modele charge), le serpent suit une
 # politique deterministe et peut tourner en rond indefiniment sans jamais

--- a/dashboard.py
+++ b/dashboard.py
@@ -122,8 +122,13 @@ class Dashboard:
         env = self.envs[i]
         state = self.states[i]
         action = self.agent.choose_action(state)
+        dist_before = self.interp.green_distance(env)
         event = env.step(action)
         reward = self.interp.get_reward(event)
+        dist_after = (self.interp.green_distance(env)
+                      if event["type"] == "nothing" else None)
+        reward += self.interp.approach_bonus(
+            dist_before, dist_after, event["type"])
         done = env.is_game_over()
 
         # Anti-blocage : on remet le compteur a zero quand le serpent mange,

--- a/environment.py
+++ b/environment.py
@@ -118,8 +118,12 @@ class Environment:
             self.snake.pop()   # deplacement normal
             self.snake.pop()   # retrait du a la pomme rouge
             self._spawn_red()
+            # Une pomme rouge qui vide le serpent est un game over : on le
+            # signale (fatal) pour que l'interpreter applique la penalite de
+            # mort, et non le simple malus de pomme rouge.
             if len(self.snake) == 0:
                 self.done = True
+                return {"type": "red", "fatal": True}
             return {"type": "red"}
 
         self.snake.pop()

--- a/interpreter.py
+++ b/interpreter.py
@@ -43,23 +43,67 @@ class Interpreter:
         return {action: self._ray(env, action)
                 for action in constants.ACTIONS}
 
+    @staticmethod
+    def _first_distance(ray, char):
+        """Distance en cases jusqu'a la 1re occurrence de char sur un rayon.
+
+        None si char est absent du rayon. La case adjacente a la tete est a
+        distance 1 (le rayon exclut la tete).
+        """
+        for i, cell in enumerate(ray):
+            if cell == char:
+                return i + 1
+        return None
+
     def get_state(self, env):
         """Reduit la vision en une cle hashable pour la Q-table.
 
-        Par direction : danger adjacent (mur ou corps), pomme verte
-        visible, pomme rouge visible. Etat = tuple de 12 bits, independant
-        de la taille du board.
+        Par direction : danger adjacent (mur ou corps), pomme verte visible,
+        pomme rouge visible. Etat = tuple de 12 bits, independant de la taille
+        du board. Le gradient vers la nourriture est fourni par le reward
+        shaping (approach_bonus), pas par l'etat : coder la distance ici
+        multiplie l'espace d'etats sans gain de perf mesurable.
         """
         features = []
         for action in constants.ACTIONS:
             ray = self._ray(env, action)
-            adjacent = ray[0]
-            danger = int(adjacent in (constants.CELL_WALL,
-                                      constants.CELL_BODY))
+            danger = int(ray[0] in (constants.CELL_WALL,
+                                    constants.CELL_BODY))
             green = int(constants.CELL_GREEN in ray)
             red = int(constants.CELL_RED in ray)
             features.extend((danger, green, red))
         return tuple(features)
+
+    def green_distance(self, env):
+        """Distance en cases jusqu'a la pomme verte visible la plus proche.
+
+        Balaie les 4 rayons depuis la tete ; retourne le plus petit nombre de
+        cases separant la tete d'une pomme verte alignee, ou None si aucune
+        pomme verte n'est visible. Purement derive de la vision.
+        """
+        if not env.snake:
+            return None
+        best = None
+        for action in constants.ACTIONS:
+            ray = self._ray(env, action)
+            distance = self._first_distance(ray, constants.CELL_GREEN)
+            if distance is not None and (best is None or distance < best):
+                best = distance
+        return best
+
+    def approach_bonus(self, dist_before, dist_after, event_type):
+        """Bonus de reward pour le rapprochement d'une pomme verte visible.
+
+        Applique seulement sur un deplacement simple (event "nothing") ou une
+        pomme verte reste visible avant et apres : positif si le serpent s'est
+        rapproche, negatif s'il s'est eloigne, nul a distance constante.
+        Les pas ou l'on mange/meurt sont deja geres par les rewards de base.
+        """
+        if event_type != "nothing":
+            return 0.0
+        if dist_before is None or dist_after is None:
+            return 0.0
+        return constants.REWARD_APPROACH * (dist_before - dist_after)
 
     def get_reward(self, event):
         """Calcule la recompense associee a une transition de l'env."""
@@ -67,6 +111,10 @@ class Interpreter:
         if kind == "green":
             return constants.REWARD_GREEN
         if kind == "red":
+            # Une pomme rouge qui reduit le serpent a zero est une mort :
+            # elle est penalisee comme un game over, pas comme un simple malus.
+            if event.get("fatal"):
+                return constants.REWARD_GAMEOVER
             return constants.REWARD_RED
         if kind in ("wall", "collision", "gameover"):
             return constants.REWARD_GAMEOVER

--- a/main.py
+++ b/main.py
@@ -68,8 +68,14 @@ def run_session(env, interp, agent, learn, verbose, step_by_step,
             else:
                 _wait_step()
 
+        dist_before = interp.green_distance(env)
         event = env.step(action)
         reward = interp.get_reward(event)
+        # dist_after n'a de sens que sur un deplacement simple : apres avoir
+        # mange/perdu, le serpent peut etre vide ou la pomme a bouge.
+        dist_after = (interp.green_distance(env)
+                      if event["type"] == "nothing" else None)
+        reward += interp.approach_bonus(dist_before, dist_after, event["type"])
         stall = 0 if event["type"] == "green" else stall + 1
         done = env.is_game_over() or stall >= stall_limit
         next_state = None if done else interp.get_state(env)

--- a/tests/test_red_apple_fatal.py
+++ b/tests/test_red_apple_fatal.py
@@ -1,0 +1,76 @@
+"""Regression : une pomme rouge qui vide le serpent ne doit pas crasher.
+
+Bug historique : quand une pomme rouge reduit le serpent a une longueur de 0,
+`environment.step` renvoie sans probleme, mais l'appel suivant a
+`interpreter.green_distance` lisait `env.snake[0]` sur une liste vide et levait
+une IndexError (crash = 0 a l'evaluation). On verifie ici :
+  1. l'evenement renvoye est bien un game over "fatal" ;
+  2. le reward correspondant est la penalite de mort, pas le simple malus ;
+  3. green_distance est robuste au serpent vide ;
+  4. une session complete se joue sans exception dans ce scenario.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import constants                                # noqa: E402
+from environment import Environment            # noqa: E402
+from interpreter import Interpreter            # noqa: E402
+
+
+def _one_length_snake_next_to_red():
+    """Env force : serpent d'1 case, pomme rouge juste a droite de la tete."""
+    env = Environment()
+    env.done = False
+    env.snake = [(5, 5)]
+    env.direction = constants.RIGHT
+    env.green_apples = [(0, 0)]
+    env.red_apples = [(5, 6)]
+    return env
+
+
+def test_fatal_red_apple_event_and_reward():
+    env = _one_length_snake_next_to_red()
+    interp = Interpreter()
+
+    event = env.step(constants.RIGHT)
+
+    assert event["type"] == "red"
+    assert event.get("fatal") is True
+    assert env.snake == []
+    assert env.is_game_over() is True
+    assert interp.get_reward(event) == constants.REWARD_GAMEOVER
+
+
+def test_green_distance_handles_empty_snake():
+    env = _one_length_snake_next_to_red()
+    interp = Interpreter()
+    env.step(constants.RIGHT)          # serpent vide desormais
+    # Ne doit pas lever : renvoie simplement None (aucune vision possible).
+    assert interp.green_distance(env) is None
+
+
+def test_non_fatal_red_apple_keeps_malus():
+    env = Environment()
+    env.done = False
+    env.snake = [(5, 5), (5, 4)]       # longueur 2 -> restera 1 apres la rouge
+    env.direction = constants.RIGHT
+    env.green_apples = [(0, 0)]
+    env.red_apples = [(5, 6)]
+    interp = Interpreter()
+
+    event = env.step(constants.RIGHT)
+
+    assert event["type"] == "red"
+    assert event.get("fatal") is None
+    assert env.is_game_over() is False
+    assert interp.get_reward(event) == constants.REWARD_RED
+
+
+if __name__ == "__main__":
+    test_fatal_red_apple_event_and_reward()
+    test_green_distance_handles_empty_snake()
+    test_non_fatal_red_apple_keeps_malus()
+    print("OK - tous les tests de regression passent")


### PR DESCRIPTION
## Contexte

Analyse du code : le serpent peut atteindre la longueur 1 (3 → 2 → 1 via pommes rouges), puis en manger une autre → longueur 0 → game over. Mais la boucle appelait ensuite `interpreter.green_distance(env)` sur un serpent vide → `env.snake[0]` levait une **`IndexError`** → **crash = 0 à l'évaluation**.

Ce bug vit dans la feature *reward shaping* (encore non mergée sur `main`), donc cette PR livre la feature **et** son correctif ensemble.

## Feature — reward shaping
- `green_distance` / `approach_bonus` dans l'interpreter : bonus proportionnel à la réduction de distance à la pomme verte visible la plus proche, dérivé **uniquement des rayons de vision** (conforme à la contrainte « vision seule »).
- `REWARD_APPROACH` dans `constants`.
- Branchement dans `run_session` (main) et `_step_board` (dashboard).

## Fix — crash pomme rouge fatale
- `environment.step` signale le cas fatal via `{"type": "red", "fatal": True}`.
- `get_reward` applique alors la pénalité de mort (**-100**) au lieu du simple malus **-20** (l'agent apprend enfin que se réduire à 0 est mortel).
- Le shaping n'est calculé que sur un pas `"nothing"` (main + dashboard), jamais sur un pas terminal.
- `green_distance` renvoie `None` sur un serpent vide (double sécurité).

## Tests
- `tests/test_red_apple_fatal.py` : 3 cas (événement fatal + reward, robustesse serpent vide, pomme rouge non-fatale conserve -20).
- `flake8` : propre.
- Smoke test : 30 sessions headless sans exception.