### PR TITLE
Fix: garde-fou taille de board < longueur initiale du serpent

### DIFF
--- a/src/snakeai/core/environment.py
+++ b/src/snakeai/core/environment.py
@@ -17,6 +17,12 @@ class Environment:
     """Board carre et regles du Snake."""
 
     def __init__(self, size=constants.BOARD_SIZE):
+        if size < constants.SNAKE_START_LENGTH:
+            raise ValueError(
+                "size ({}) doit etre >= a la longueur initiale du serpent "
+                "({}), sinon aucun placement n'est possible."
+                .format(size, constants.SNAKE_START_LENGTH)
+            )
         self.size = size
         self.snake = []          # [(ligne, colonne), ...], tete en tete
         self.direction = None

--- a/tests/test_environment_size_guard.py
+++ b/tests/test_environment_size_guard.py
@@ -1,0 +1,35 @@
+"""Regression : un board plus petit que le serpent initial ne doit pas
+faire tourner `_place_snake` en boucle infinie.
+
+Bug historique : `Environment.__init__` ne verifiait pas que `size` etait
+suffisant pour placer un serpent de `constants.SNAKE_START_LENGTH` cellules
+alignees. Avec un board trop petit, aucun placement n'est jamais possible
+dans les limites et la boucle `while True` de `_place_snake` tourne pour
+toujours (freeze silencieux). On verifie ici :
+  1. `Environment(size=1)` leve bien une ValueError explicite ;
+  2. la taille par defaut reste fonctionnelle.
+"""
+
+from snakeai import constants
+from snakeai.core import Environment
+
+
+def test_size_below_snake_length_raises_value_error():
+    try:
+        Environment(size=1)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_default_size_still_works():
+    env = Environment()
+    assert env.size == constants.BOARD_SIZE
+    assert len(env.snake) == constants.SNAKE_START_LENGTH
+
+
+if __name__ == "__main__":
+    test_size_below_snake_length_raises_value_error()
+    test_default_size_still_works()
+    print("OK - tous les tests de regression passent")


### PR DESCRIPTION
## Contexte

Dans `src/snakeai/core/environment.py`, `Environment._place_snake` tire au hasard une tete et une direction, puis verifie que les `SNAKE_START_LENGTH` cellules du serpent tiennent dans le board. Si `size < constants.SNAKE_START_LENGTH`, aucun placement aligne n'est jamais possible dans les limites : la boucle `while True` tourne indefiniment (freeze silencieux, pas un crash, mais tout aussi problematique a l'evaluation).

Cela concerne notamment le bonus "board size variable", qui rend `size` potentiellement configurable.

## Correctif

Ajout d'une garde explicite dans `Environment.__init__`, avant l'appel a `reset()` : si `size < constants.SNAKE_START_LENGTH`, on leve une `ValueError` avec un message explicite plutot que de laisser la boucle de placement tourner sans fin.

Correctif minimal et cible : aucun autre comportement n'est modifie.

## Tests

- Nouveau fichier `tests/test_environment_size_guard.py` :
  - `Environment(size=1)` leve bien une `ValueError` ;
  - `Environment()` (taille par defaut) reste fonctionnel.
- Suite de tests existante (3 tests) toujours au vert.
- `flake8 .` toujours a 0 erreur.
- Sanity check : `./snake -sessions 3 -visual off` s'execute sans erreur (taille de board par defaut 10, largement au-dessus du seuil de garde).

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeC5uJErg4SLKXbbz6G832

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeC5uJErg4SLKXbbz6G832)_