### PR TITLE
Add .claude/ to .gitignore for local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 
 # Snapshots auto-sauvegardes par le dashboard (artefacts d'entrainement)
 models/model_gen*.txt
+
+# Worktrees locaux crees par le harness Claude Code pour les sous-agents
+.claude/


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude the `.claude/` directory, which contains local worktrees created by the Claude Code harness for sub-agents.

## Changes
- Added `.claude/` directory to `.gitignore` with explanatory comment in French, following the project's language convention

## Details
This prevents local development artifacts generated by Claude Code's harness from being tracked in version control, keeping the repository clean and focused on source code and required model artifacts.

https://claude.ai/code/session_01JeC5uJErg4SLKXbbz6G832