### PR TITLE
Bonus : -seed, -board-size, records de longueur, mode benchmark

### DIFF
--- a/src/snakeai/cli.py
+++ b/src/snakeai/cli.py
@@ -6,12 +6,17 @@ et de deleguer soit au trainer, soit au dashboard.
 """
 
 import argparse
+import random
 import sys
 
+from snakeai import constants
 from snakeai.core import Environment
 from snakeai.learning import Agent
 from snakeai.perception import Interpreter
 from snakeai.training import train
+
+# Paliers de longueur du bonus "Records atteints" (cf. sujet 42).
+LENGTH_MILESTONES = (15, 20, 25, 30, 35)
 
 
 def parse_args(argv=None):
@@ -37,12 +42,24 @@ def parse_args(argv=None):
                         help="vue parallele : une grille de parties a la fois")
     parser.add_argument("-grid", type=int, default=6,
                         help="cote de la grille du dashboard (grid x grid)")
+    parser.add_argument("-seed", type=int, default=None,
+                        help="graine aleatoire pour des runs reproductibles")
+    parser.add_argument("-board-size", dest="board_size", type=int,
+                        default=None,
+                        help="cote du board (defaut : constants.BOARD_SIZE)")
+    parser.add_argument("-benchmark", action="store_true",
+                        help="agrege longueur/duree de toutes les sessions")
     return parser.parse_args(argv)
 
 
 def main():
     """Point d'entree du programme."""
     args = parse_args()
+    if args.seed is not None:
+        # Graine le module `random` global : utilise a la fois par
+        # Environment (placement serpent/pommes) et Agent (epsilon-greedy),
+        # donc suffisant pour rendre un run reproductible.
+        random.seed(args.seed)
 
     agent = _build_agent(args)
     learn = not args.dontlearn
@@ -53,13 +70,19 @@ def main():
         return
 
     display = _make_display(args.visual == "on")
-    env = Environment()
-    best_length, best_duration = train(env, interp, agent, args, display)
+    size = args.board_size if args.board_size is not None \
+        else constants.BOARD_SIZE
+    env = Environment(size=size)
+    best_length, best_duration, lengths, durations = train(
+        env, interp, agent, args, display)
     if display is not None:
         display.close()
 
     print("Game over, max length = {}, max duration = {}"
           .format(best_length, best_duration))
+    _print_records(best_length)
+    if args.benchmark:
+        _print_benchmark(lengths, durations)
     _save_model(agent, args.save)
 
 
@@ -86,6 +109,28 @@ def _save_model(agent, path):
     else:
         print("Avertissement : echec de la sauvegarde dans {}"
               .format(path), file=sys.stderr)
+
+
+def _print_records(best_length):
+    """Affiche les paliers de longueur (15/20/25/30/35) atteints ou non."""
+    marks = " ".join(
+        "{} [{}]".format(
+            milestone, "OK" if best_length >= milestone else "--")
+        for milestone in LENGTH_MILESTONES
+    )
+    print("Records atteints : {}".format(marks))
+
+
+def _print_benchmark(lengths, durations):
+    """Affiche les stats agregees (mean/min/max) du mode `-benchmark`."""
+    if not lengths:
+        return
+    print("Benchmark ({} sessions) :".format(len(lengths)))
+    print("  Longueur - mean = {:.2f}, min = {}, max = {}"
+          .format(sum(lengths) / len(lengths), min(lengths), max(lengths)))
+    print("  Duree    - mean = {:.2f}, min = {}, max = {}"
+          .format(sum(durations) / len(durations), min(durations),
+                  max(durations)))
 
 
 def _run_dashboard(agent, interp, learn, args):

--- a/src/snakeai/training/trainer.py
+++ b/src/snakeai/training/trainer.py
@@ -70,15 +70,25 @@ def _wait_step():
 
 
 def train(env, interp, agent, args, display=None):
-    """Enchaine les sessions d'entrainement et retourne (best_len, best_dur).
+    """Enchaine les sessions d'entrainement.
+
+    Retourne (best_length, best_duration, lengths, durations) : les deux
+    premiers champs sont inchanges par rapport au comportement historique
+    (max sur toutes les sessions). Les deux derniers sont les listes brutes
+    par session, remplies uniquement si `args.benchmark` est vrai (sinon
+    listes vides) : elles permettent a l'appelant de calculer des stats
+    agregees (mode `-benchmark`) sans recalcul ni session supplementaire.
 
     Applique le decay d'epsilon apres chaque session (sauf en `-dontlearn`),
     imprime le bilan de chaque partie et s'arrete si l'affichage est ferme.
     """
     learn = not args.dontlearn
     verbose = args.visual == "on" or args.step_by_step
+    benchmark = getattr(args, "benchmark", False)
     best_length = 0
     best_duration = 0
+    lengths = []
+    durations = []
 
     for session in range(1, args.sessions + 1):
         length, duration = run_session(
@@ -89,9 +99,12 @@ def train(env, interp, agent, args, display=None):
             agent.decay_epsilon()
         best_length = max(best_length, length)
         best_duration = max(best_duration, duration)
+        if benchmark:
+            lengths.append(length)
+            durations.append(duration)
         print("Session {}/{} - Game over, max length = {}, max duration = {}"
               .format(session, args.sessions, length, duration))
         if display is not None and display.should_quit():
             break
 
-    return best_length, best_duration
+    return best_length, best_duration, lengths, durations


### PR DESCRIPTION
## Contexte

Ajoute quatre petites features CLI/training bonus, regroupees dans une seule PR car elles touchent les memes fichiers (`cli.py`, `training/trainer.py`). Bonus, non rattache a une issue.

## Features

1. **`-seed N`** : graine `random.seed(args.seed)` en debut de `main()` avant toute construction d'Environment/Agent, pour des runs reproductibles (Environment et Agent utilisent tous les deux le module `random` global, donc une seule graine suffit).
   ```
   ./snake -sessions 5 -visual off -seed 42
   ```

2. **`-board-size N`** : taille du board configurable, transmise a `Environment(size=...)`. L'encodage d'etat (`Interpreter.get_state`) est deja independant de la taille du board, donc aucun autre changement n'est necessaire.
   ```
   ./snake -sessions 3 -visual off -board-size 14
   ```

3. **Records de longueur (15/20/25/30/35)** : a la fin de chaque run, une ligne supplementaire indique quels paliers ont ete atteints (`best_length` couvre deja le max sur toutes les sessions) :
   ```
   Records atteints : 15 [OK] 20 [--] 25 [--] 30 [--] 35 [--]
   ```
   Affichage systematique, aucun nouveau flag necessaire.

4. **`-benchmark`** : agrege longueur/duree de chaque session (pas seulement le max) et affiche mean/min/max en fin de run.
   ```
   ./snake -sessions 20 -visual off -dontlearn -benchmark
   ```
   `train()` retourne desormais `(best_length, best_duration, lengths, durations)` ; les deux dernieres listes restent vides quand `-benchmark` n'est pas passe, donc le comportement/l'affichage par defaut est inchange.

## Validation

- `flake8 .` -> 0 erreur.
- `PYTHONPATH=src python -m pytest tests/ -q` -> 5 passed.
- `PYTHONPATH=src SDL_VIDEODRIVER=dummy python -m snakeai -sessions 5 -visual off -seed 42` execute deux fois -> sorties strictement identiques (diff vide).
- `PYTHONPATH=src SDL_VIDEODRIVER=dummy python -m snakeai -sessions 3 -visual off -board-size 14` -> OK, pas de crash.
- `PYTHONPATH=src SDL_VIDEODRIVER=dummy python -m snakeai -sessions 5 -visual off -dontlearn -benchmark` -> stats agregees affichees.
- Run standard `PYTHONPATH=src SDL_VIDEODRIVER=dummy python -m snakeai -sessions 5 -visual off` (sans nouveau flag) -> comportement inchange, avec en plus la ligne "Records atteints" (ajout additif attendu du point 3).

Seuls `src/snakeai/cli.py` et `src/snakeai/training/trainer.py` sont modifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeC5uJErg4SLKXbbz6G832

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeC5uJErg4SLKXbbz6G832)_